### PR TITLE
General cleanup + expose a client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,13 +9,23 @@ import (
 	"net/http"
 )
 
+type OsoClient interface {
+	Authorize(actor Instance, action string, resource Instance) (bool, error)
+	List(actor Instance, action string, resource Type) ([]int, error)
+	AddRelation(from Instance, name string, to Instance) error
+	DeleteRelation(from Instance, name string, to Instance) error
+	AddRole(actor Instance, name string, resource Instance) error
+	DeleteRole(actor Instance, name string, resource Instance) error
+	GetResourceRoleForActor(resource Instance, role string, actor Instance) ([]Role, error)
+}
+
 type Client struct {
 	url    string
 	apiKey string
 	// TODO(gj): configurable logging?
 }
 
-func NewClient(url string, apiKey string) Client {
+func NewClient(url string, apiKey string) OsoClient {
 	return Client{url, apiKey}
 }
 

--- a/client.go
+++ b/client.go
@@ -19,14 +19,14 @@ type OsoClient interface {
 	GetResourceRoleForActor(resource Instance, role string, actor Instance) ([]Role, error)
 }
 
-type Client struct {
+type client struct {
 	url    string
 	apiKey string
 	// TODO(gj): configurable logging?
 }
 
 func NewClient(url string, apiKey string) OsoClient {
-	return Client{url, apiKey}
+	return client{url, apiKey}
 }
 
 type Instance interface {
@@ -46,7 +46,7 @@ type Role struct {
 	ActorType    string `json:"actor_type"`
 }
 
-func (c Client) apiCall(method string, path string, body io.Reader) (*http.Request, error) {
+func (c client) apiCall(method string, path string, body io.Reader) (*http.Request, error) {
 	url := c.url + "/api" + path
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -59,7 +59,7 @@ func (c Client) apiCall(method string, path string, body io.Reader) (*http.Reque
 	return req, nil
 }
 
-func (c Client) get(path string) (*http.Response, error) {
+func (c client) get(path string) (*http.Response, error) {
 	req, err := c.apiCall("GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (c Client) get(path string) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func (c Client) post(path string, body io.Reader) (*http.Response, error) {
+func (c client) post(path string, body io.Reader) (*http.Response, error) {
 	req, err := c.apiCall("POST", path, body)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (c Client) post(path string, body io.Reader) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func (c Client) delete(path string, body io.Reader) (*http.Response, error) {
+func (c client) delete(path string, body io.Reader) (*http.Response, error) {
 	req, err := c.apiCall("DELETE", path, body)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (c Client) delete(path string, body io.Reader) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func (c Client) Authorize(actor Instance, action string, resource Instance) (bool, error) {
+func (c client) Authorize(actor Instance, action string, resource Instance) (bool, error) {
 	payload := struct {
 		ActorType    string `json:"actor_type"`
 		ActorID      string `json:"actor_id"`
@@ -131,7 +131,7 @@ func (c Client) Authorize(actor Instance, action string, resource Instance) (boo
 	return resBody.Allowed, nil
 }
 
-func (c Client) List(actor Instance, action string, resource Type) ([]int, error) {
+func (c client) List(actor Instance, action string, resource Type) ([]int, error) {
 	payload := struct {
 		ActorType    string `json:"actor_type"`
 		ActorID      string `json:"actor_id"`
@@ -183,7 +183,7 @@ type relationReq struct {
 	ToType   string `json:"to_type"`
 }
 
-func (c Client) AddRelation(from Instance, name string, to Instance) error {
+func (c client) AddRelation(from Instance, name string, to Instance) error {
 	reqBody := relationReq{
 		FromID:   from.Id(),
 		FromType: from.Type(),
@@ -211,7 +211,7 @@ func (c Client) AddRelation(from Instance, name string, to Instance) error {
 	return nil
 }
 
-func (c Client) DeleteRelation(from Instance, name string, to Instance) error {
+func (c client) DeleteRelation(from Instance, name string, to Instance) error {
 	reqBody := relationReq{
 		FromID:   from.Id(),
 		FromType: from.Type(),
@@ -239,7 +239,7 @@ func (c Client) DeleteRelation(from Instance, name string, to Instance) error {
 	return nil
 }
 
-func (c Client) AddRole(actor Instance, name string, resource Instance) error {
+func (c client) AddRole(actor Instance, name string, resource Instance) error {
 	reqBody := Role{
 		ActorID:      actor.Id(),
 		ActorType:    actor.Type(),
@@ -267,7 +267,7 @@ func (c Client) AddRole(actor Instance, name string, resource Instance) error {
 	return nil
 }
 
-func (c Client) DeleteRole(actor Instance, name string, resource Instance) error {
+func (c client) DeleteRole(actor Instance, name string, resource Instance) error {
 	reqBody := Role{
 		ActorID:      actor.Id(),
 		ActorType:    actor.Type(),
@@ -296,7 +296,7 @@ func (c Client) DeleteRole(actor Instance, name string, resource Instance) error
 }
 
 // TODO(gj): Do we need equivalent of Oso::Client::get_roles in Ruby client?
-func (c Client) GetResourceRoleForActor(resource Instance, role string, actor Instance) ([]Role, error) {
+func (c client) GetResourceRoleForActor(resource Instance, role string, actor Instance) ([]Role, error) {
 	req, e := c.apiCall("GET", "/roles", nil)
 	if e != nil {
 		return nil, e

--- a/client.go
+++ b/client.go
@@ -28,16 +28,12 @@ type Type interface {
 	Type() string
 }
 
-type AuthorizeReq struct {
-	ActorType    string `json:"actor_type"`
-	ActorId      string `json:"actor_id"`
-	Action       string `json:"action"`
+type Role struct {
+	ResourceID   string `json:"resource_id"`
 	ResourceType string `json:"resource_type"`
-	ResourceId   string `json:"resource_id"`
-}
-
-type AuthorizeRes struct {
-	allowed bool
+	Role         string `json:"role"`
+	ActorID      string `json:"actor_id"`
+	ActorType    string `json:"actor_type"`
 }
 
 func (c Client) apiCall(method string, path string, body io.Reader) (*http.Request, error) {
@@ -81,110 +77,115 @@ func (c Client) delete(path string, body io.Reader) (*http.Response, error) {
 }
 
 func (c Client) Authorize(actor Instance, action string, resource Instance) (bool, error) {
-	payload := AuthorizeReq{
+	payload := struct {
+		ActorType    string `json:"actor_type"`
+		ActorID      string `json:"actor_id"`
+		Action       string `json:"action"`
+		ResourceType string `json:"resource_type"`
+		ResourceID   string `json:"resource_id"`
+	}{
 		ActorType:    actor.Type(),
-		ActorId:      actor.Id(),
+		ActorID:      actor.Id(),
 		Action:       action,
 		ResourceType: resource.Type(),
-		ResourceId:   resource.Id(),
+		ResourceID:   resource.Id(),
 	}
 
-	reqBodyJson, e := json.Marshal(payload)
+	reqBodyJSON, e := json.Marshal(payload)
 	if e != nil {
 		return false, e
 	}
 
-	reqBody := bytes.NewBuffer(reqBodyJson)
+	reqBody := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.post("/authorize", reqBody)
 	if e != nil {
 		return false, e
 	}
 	defer res.Body.Close()
 
-	resBodyJson, e := ioutil.ReadAll(res.Body)
+	resBodyJSON, e := ioutil.ReadAll(res.Body)
 	if e != nil {
 		return false, e
 	}
 	if res.StatusCode != 200 {
-		return false, errors.New(string(resBodyJson))
+		return false, errors.New(string(resBodyJSON))
 	}
 
-	var resBody AuthorizeRes
-	e = json.Unmarshal(resBodyJson, &resBody)
+	var resBody struct {
+		Allowed bool `json:"allowed"`
+	}
+	e = json.Unmarshal(resBodyJSON, &resBody)
 	if e != nil {
 		return false, e
 	}
-	return resBody.allowed, nil
-}
-
-type ListReq struct {
-	ActorType    string `json:"actor_type"`
-	ActorId      string `json:"actor_id"`
-	Action       string `json:"action"`
-	ResourceType string `json:"resource_type"`
-}
-
-type ListRes struct {
-	results []int
+	return resBody.Allowed, nil
 }
 
 func (c Client) List(actor Instance, action string, resource Type) ([]int, error) {
-	payload := ListReq{
+	payload := struct {
+		ActorType    string `json:"actor_type"`
+		ActorID      string `json:"actor_id"`
+		Action       string `json:"action"`
+		ResourceType string `json:"resource_type"`
+	}{
 		ActorType:    actor.Type(),
-		ActorId:      actor.Id(),
+		ActorID:      actor.Id(),
 		Action:       action,
 		ResourceType: resource.Type(),
 	}
 
-	reqBodyJson, e := json.Marshal(payload)
+	reqBodyJSON, e := json.Marshal(payload)
 	if e != nil {
 		return nil, e
 	}
 
-	reqBody := bytes.NewBuffer(reqBodyJson)
+	reqBody := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.post("/list", reqBody)
 	if e != nil {
 		return nil, e
 	}
 	defer res.Body.Close()
 
-	resBodyJson, e := ioutil.ReadAll(res.Body)
+	resBodyJSON, e := ioutil.ReadAll(res.Body)
 	if e != nil {
 		return nil, e
 	}
 	if res.StatusCode != 200 {
-		return nil, errors.New(string(resBodyJson))
+		return nil, errors.New(string(resBodyJSON))
 	}
 
+	type ListRes struct {
+		Results []int `json:"results"`
+	}
 	var resBody ListRes
-	e = json.Unmarshal(resBodyJson, &resBody)
+	e = json.Unmarshal(resBodyJSON, &resBody)
 	if e != nil {
 		return nil, e
 	}
-	return resBody.results, nil
+	return resBody.Results, nil
 }
 
-type RelationReq struct {
-	FromId   string `json:"from_id"`
+type relationReq struct {
+	FromID   string `json:"from_id"`
 	FromType string `json:"from_type"`
 	Relation string `json:"relation"`
-	ToId     string `json:"to_id"`
+	ToID     string `json:"to_id"`
 	ToType   string `json:"to_type"`
 }
 
 func (c Client) AddRelation(from Instance, name string, to Instance) error {
-	reqBody := RelationReq{
-		FromId:   from.Id(),
+	reqBody := relationReq{
+		FromID:   from.Id(),
 		FromType: from.Type(),
 		Relation: name,
-		ToId:     to.Id(),
+		ToID:     to.Id(),
 		ToType:   to.Type(),
 	}
-	reqBodyJson, e := json.Marshal(reqBody)
+	reqBodyJSON, e := json.Marshal(reqBody)
 	if e != nil {
 		return e
 	}
-	reqBodyBytes := bytes.NewBuffer(reqBodyJson)
+	reqBodyBytes := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.post("/relations", reqBodyBytes)
 	if e != nil {
 		return e
@@ -201,18 +202,18 @@ func (c Client) AddRelation(from Instance, name string, to Instance) error {
 }
 
 func (c Client) DeleteRelation(from Instance, name string, to Instance) error {
-	reqBody := RelationReq{
-		FromId:   from.Id(),
+	reqBody := relationReq{
+		FromID:   from.Id(),
 		FromType: from.Type(),
 		Relation: name,
-		ToId:     to.Id(),
+		ToID:     to.Id(),
 		ToType:   to.Type(),
 	}
-	reqBodyJson, e := json.Marshal(reqBody)
+	reqBodyJSON, e := json.Marshal(reqBody)
 	if e != nil {
 		return e
 	}
-	reqBodyBytes := bytes.NewBuffer(reqBodyJson)
+	reqBodyBytes := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.delete("/relations", reqBodyBytes)
 	if e != nil {
 		return e
@@ -228,27 +229,19 @@ func (c Client) DeleteRelation(from Instance, name string, to Instance) error {
 	return nil
 }
 
-type Role struct {
-	ResourceId   string `json:"resource_id"`
-	ResourceType string `json:"resource_type"`
-	Role         string `json:"role"`
-	ActorId      string `json:"actor_id"`
-	ActorType    string `json:"actor_type"`
-}
-
 func (c Client) AddRole(actor Instance, name string, resource Instance) error {
 	reqBody := Role{
-		ActorId:      actor.Id(),
+		ActorID:      actor.Id(),
 		ActorType:    actor.Type(),
 		Role:         name,
-		ResourceId:   resource.Id(),
+		ResourceID:   resource.Id(),
 		ResourceType: resource.Type(),
 	}
-	reqBodyJson, e := json.Marshal(reqBody)
+	reqBodyJSON, e := json.Marshal(reqBody)
 	if e != nil {
 		return e
 	}
-	reqBodyBytes := bytes.NewBuffer(reqBodyJson)
+	reqBodyBytes := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.post("/roles", reqBodyBytes)
 	if e != nil {
 		return e
@@ -266,18 +259,21 @@ func (c Client) AddRole(actor Instance, name string, resource Instance) error {
 
 func (c Client) DeleteRole(actor Instance, name string, resource Instance) error {
 	reqBody := Role{
-		ActorId:      actor.Id(),
+		ActorID:      actor.Id(),
 		ActorType:    actor.Type(),
 		Role:         name,
-		ResourceId:   resource.Id(),
+		ResourceID:   resource.Id(),
 		ResourceType: resource.Type(),
 	}
-	reqBodyJson, e := json.Marshal(reqBody)
+	reqBodyJSON, e := json.Marshal(reqBody)
 	if e != nil {
 		return e
 	}
-	reqBodyBytes := bytes.NewBuffer(reqBodyJson)
+	reqBodyBytes := bytes.NewBuffer(reqBodyJSON)
 	res, e := c.post("/roles", reqBodyBytes)
+	if e != nil {
+		return e
+	}
 	defer res.Body.Close()
 	resBody, e := ioutil.ReadAll(res.Body)
 	if e != nil {
@@ -307,15 +303,15 @@ func (c Client) GetResourceRoleForActor(resource Instance, role string, actor In
 		return nil, e
 	}
 	defer res.Body.Close()
-	resBodyJson, e := ioutil.ReadAll(res.Body)
+	resBodyJSON, e := ioutil.ReadAll(res.Body)
 	if e != nil {
 		return nil, e
 	}
 	if res.StatusCode != 200 {
-		return nil, errors.New(string(resBodyJson))
+		return nil, errors.New(string(resBodyJSON))
 	}
 	var resBody []Role
-	e = json.Unmarshal(resBodyJson, &resBody)
+	e = json.Unmarshal(resBodyJSON, &resBody)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
Hi there,

This PR:
- Cleans up a few linter errors - namely some uncaught errors, consistency in abbreviation casing
- Make a fair few redundant exports private -- these types are only used within the implementation, types that are returned to the client or used as inputs are still exported.
- Adds an `OsoClient` interface. This is particularly useful for setting up mocks, and adds readability + structure

There isn't any breaking changes, the API has not been changed -- so this can be a major increment to the tag.